### PR TITLE
Enable option updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,8 @@ A file with all default options and their descriptions is included in the repo.
 ## Disabling for specific directories
 It is possible to disable logging of specific files with any criteria that can be queried through [auto profiles](https://mpv.io/manual/master/#conditional-auto-profiles).  
 Below is an example to exclude files when "MyCunnyFolder" is part of the directory path.  
-This goes in `mpv.conf`. The first line should be placed at the top, before any profiles.
+This goes in `mpv.conf`.
 ```ini
-script-opts-append=memo-enabled=yes
-
 [dont-log-my-porn]
 profile-cond=string.match(string.lower(string.gsub(require "mp.utils".join_path(get("working-directory", ""), get("path", "")), string.gsub(get("filename", ""), "([^%w])", "%%%1").."$", "")), "mycunnyfolder")~=nil
 profile-restore=copy-equal

--- a/memo.lua
+++ b/memo.lua
@@ -45,7 +45,7 @@ local script_name = mp.get_script_name()
 
 mp.utils = require "mp.utils"
 mp.options = require "mp.options"
-mp.options.read_options(options, "memo")
+mp.options.read_options(options, "memo", function(list) end)
 
 local assdraw = require "mp.assdraw"
 
@@ -712,8 +712,6 @@ function show_history(entries, next_page, prev_page, update, return_items)
 end
 
 function file_load()
-    mp.options.read_options(options, "memo")
-
     if options.enabled then
         write_history()
     end


### PR DESCRIPTION
Updating options via script-opts-append already worked, however it required to actually have the option in script-opts in order to change it's value. That means it was e.g. not possiblet to remove an option from script-opts to fall back to the value configured in the .conf file.

By enabling option updates the script-opts always get applied on top of the original configuration, which means removing an option from script-opts now also restores the original value.

This removes the need for setting default script-opts when changing options via conditional profiles.