### PR TITLE
Don't rely on escaped filename in profile-cond

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This goes in `mpv.conf`. The first line should be placed at the top, before any 
 script-opts-append=memo-enabled=yes
 
 [dont-log-my-porn]
-profile-cond=string.match(string.lower(string.gsub(require "mp.utils".join_path(get("working-directory", ""), get("path", "")), string.gsub(get("filename", ""), "([^%w])", "%%%1").."$", "")), "mycunnyfolder")~=nil
+profile-cond=require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len() - 1):lower():match("mycunnyfolder")~=nil
 profile-restore=copy-equal
 script-opts-append=memo-enabled=no
 ```


### PR DESCRIPTION
Relying on escaping the filename seems error prone.
This is shorter, more readable, and can't break due to weird filenames.
It's probably also faster, not that it really matters in this case.