### PR TITLE
Improve conditional profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Below is an example to exclude files when "MyCunnyFolder" is part of the directo
 This goes in `mpv.conf`.
 ```ini
 [dont-log-my-porn]
-profile-cond=require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len() - 1):lower():match("mycunnyfolder")~=nil
+profile-cond=require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len() - 1):lower():find("mycunnyfolder", 1, true)~=nil
 profile-restore=copy-equal
 script-opts-append=memo-enabled=no
 ```

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ A file with all default options and their descriptions is included in the repo.
 
 ## Disabling for specific directories
 It is possible to disable logging of specific files with any criteria that can be queried through [auto profiles](https://mpv.io/manual/master/#conditional-auto-profiles).  
-Below is an example to exclude files when "MyCunnyFolder" is part of the directory path.  
+Below is an example to exclude files when "MyCunnyFolder" or "MyCunnyFolder2" is part of the directory path.  
 This goes in `mpv.conf`.
 ```ini
 [dont-log-my-porn]
-profile-cond=require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len() - 1):lower():find("mycunnyfolder", 1, true)~=nil
+profile-cond=(function() local ignored, path = {"mycunnyfolder", "mycunnyfolder2"}, require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len()-1):lower() for _, ig in ipairs(ignored) do if path:find(ig, 1, true) then return true end end end)()
 profile-restore=copy-equal
 script-opts-append=memo-enabled=no
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Below is an example to exclude files when "MyCunnyFolder" or "MyCunnyFolder2" is
 This goes in `mpv.conf`.
 ```ini
 [dont-log-my-porn]
-profile-cond=(function() local ignored, path = {"mycunnyfolder", "mycunnyfolder2"}, require "mp.utils".join_path(get("working-directory", ""), get("path", "")):sub(1, -get("filename", ""):len()-1):lower() for _, ig in ipairs(ignored) do if path:find(ig, 1, true) then return true end end end)()
+profile-cond=(function() local ignored, path = {"mycunnyfolder", "mycunnyfolder2"}, get("path", "") path = (path:find("^%a[%w%.%-%+]-://") and path or require "mp.utils".join_path(get("working-directory", ""), path)):sub(1, -get("filename", ""):len()-1):lower() for _, ig in ipairs(ignored) do if path:find(ig, 1, true) then return true end end end)()
 profile-restore=copy-equal
 script-opts-append=memo-enabled=no
 ```


### PR DESCRIPTION
I have used the method with two profiles for a while now and it works fine, but I wanted the ability to exclude multiple paths with that method, and this is the result of that. It's probably quite a bit slower then before, but that shouldn't cause any problems.

Better support for URLs would also be great, but we'd have to add an URL check for that.
URLs actually already work, but are treated as relative paths, so the working-directory gets prefixed, which might result in false positives. I could port my URL-check from [quality-menu ](https://github.com/christoph-heinrich/mpv-quality-menu/blob/9bb4d87681b9765a8035158c9076f4a37b6f7b07/quality-menu.lua#L505-L513)if you think that's worth it.