### PR TITLE
Add user defined directory menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # memo
-A recent files menu for mpv.
+A recent files and directories menu for mpv.
 
 This script saves your watch history, and displays it in a nice menu.
 
@@ -38,6 +38,15 @@ Brings up a search box, type your keywords and press Enter. This finds entries t
 Writes an entry for the current file. Intended for manual bookmarking with `enabled=no`.
 
 Navigation keybinds for vanilla menu can be configured through `script-opts/memo.conf`.
+
+## Script messages
+Just like the keybindings above, script messages can also be bound to keys in `input.conf`.  
+Example usage: `H script-message-to memo memo-dirs "My-Movies|pattern:TV Shows/.-/|Anime"`
+
+`memo-dirs (path_prefixes)`  
+Similar to `memo-history`, but instead of files it shows the directories of recent files.  
+It optionally takes in custom path prefixes as a parameter with the same syntax as the option of the same name.  
+If no custom path prefixes are provided, the ones from the config are used.
 
 ## uosc menus and buttons
 Adding a menu: append ` #! History` to your `input.conf` keybind, or use this for a menu-only config.

--- a/memo.lua
+++ b/memo.lua
@@ -297,7 +297,7 @@ function has_protocol(path)
 end
 
 function menu_json(menu_items, page)
-    local title = (search_query or "History") .. " (memo)"
+    local title = (search_query or (dir_menu and "Directories" or "History")) .. " (memo)"
     if options.pagination or page ~= 1 then
         title = title .. " - Page " .. page
     end
@@ -792,14 +792,16 @@ function show_history(entries, next_page, prev_page, update, return_items)
         elseif options.hide_same_dir or dir_menu then
             dirname, basename = mp.utils.split_path(display_path)
             if dir_menu then
-                local path_sep = path_separator(dirname)
-                local parent, _ = mp.utils.split_path(dirname:sub(1, -path_sep:len() - 1))
+                if dirname == "." then return end
+                local unix_dirname = dirname:gsub("\\", "/")
+                local parent, _ = mp.utils.split_path(unix_dirname:sub(1, -2))
                 local start, stop = find_path_prefix(parent, dir_menu_prefixes)
                 if not start then
                     return
                 end
-                basename = dirname:match(path_sep .. "(.-)" .. path_sep, stop)
-                dirname = dirname:sub(1, stop + basename:len() + 1)
+                basename = unix_dirname:match("/(.-)/", stop)
+                start, stop = dirname:find(basename, stop, true)
+                dirname = dirname:sub(1, stop + 1)
             end
             if state.known_dirs[dirname] then
                 return

--- a/memo.lua
+++ b/memo.lua
@@ -58,16 +58,15 @@ local options = {
 }
 
 function parse_path_prefixes(path_prefixes)
-    local plain = {}
-    local pattern = {}
+    local patterns = {}
     for prefix in path_prefixes:gmatch('([^|]+)') do
         if prefix:find("pattern:", 1, true) == 1 then
-            pattern[#pattern + 1] = prefix:sub(9)
+            patterns[#patterns + 1] = { pattern = prefix:sub(9) }
         else
-            plain[#plain + 1] = prefix
+            patterns[#patterns + 1] = { pattern = prefix, plain = true}
         end
     end
-    return {plain = plain, pattern = pattern}
+    return patterns
 end
 
 local script_name = mp.get_script_name()
@@ -697,14 +696,8 @@ function show_history(entries, next_page, prev_page, update, return_items)
     end
 
     local function find_path_prefix(path, path_prefixes)
-        for _, plain in ipairs(path_prefixes.plain) do
-            local start, stop = path:find(plain, 1, true)
-            if start then
-                return start, stop
-            end
-        end
-        for _, pattern in ipairs(path_prefixes.pattern) do
-            local start, stop = path:find(pattern)
+        for _, prefix in ipairs(path_prefixes) do
+            local start, stop = path:find(prefix.pattern, 1, prefix.plain)
             if start then
                 return start, stop
             end

--- a/memo.lua
+++ b/memo.lua
@@ -39,13 +39,47 @@ local options = {
     select_binding = "RIGHT ENTER",
     append_binding = "Shift+RIGHT Shift+ENTER",
     close_binding = "LEFT ESC",
+
+    -- Path prefixes for the recent directory menu
+    -- This can be used to restrict the parent directory relative to which the
+    -- directories are shown.
+    -- Syntax
+    --   Prefixes are separated by | and can use Lua patterns by prefixing
+    --   them with "pattern:", otherwise they will be treated as plain text.
+    --   Pattern syntax can be found here https://www.lua.org/manual/5.1/manual.html#5.4.1
+    -- Example
+    --   path_prefixes="My-Movies|pattern:TV Shows/.-/|Anime" will show directories
+    --   that are direct subdirectories of directories named "My-Movies" as well as
+    --   "Anime", while for TV Shows the shown directories are one level below that.
+    --   Opening the file "/data/TV Shows/Comedy/Curb Your Enthusiasm/S4/E06.mkv" will
+    --   lead to "Curb Your Enthusiasm" to be shown in the directory menu. Opening
+    --   of that entry will then open that file again.
+    path_prefixes = "pattern:.*"
 }
+
+function parse_path_prefixes(path_prefixes)
+    local plain = {}
+    local pattern = {}
+    for prefix in path_prefixes:gmatch('([^|]+)') do
+        if prefix:find("pattern:", 1, true) == 1 then
+            pattern[#pattern + 1] = prefix:sub(9)
+        else
+            plain[#plain + 1] = prefix
+        end
+    end
+    return {plain = plain, pattern = pattern}
+end
 
 local script_name = mp.get_script_name()
 
 mp.utils = require "mp.utils"
 mp.options = require "mp.options"
-mp.options.read_options(options, "memo", function(list) end)
+mp.options.read_options(options, "memo", function(list)
+    if list.path_prefixes then
+        options.path_prefixes = parse_path_prefixes(options.path_prefixes)
+    end
+end)
+options.path_prefixes = parse_path_prefixes(options.path_prefixes)
 
 local assdraw = require "mp.assdraw"
 
@@ -111,6 +145,33 @@ if history == nil then
 end
 history:setvbuf("full")
 
+local platform = (function()
+    local platform = mp.get_property_native("platform")
+    if platform then
+        if platform == "windows" or platform == "darwin" then
+            return platform
+        end
+    else
+        if os.getenv("windir") ~= nil then return "windows" end
+        local homedir = os.getenv("HOME")
+        if homedir ~= nil and string.sub(homedir, 1, 6) == "/Users" then
+            return "darwin"
+        end
+    end
+    return "linux"
+end)()
+
+local path_separator = (function()
+	local os_separator = platform == "windows" and "\\" or "/"
+
+	-- Get appropriate path separator for the given path.
+	---@param path string
+	---@return string
+	return function(path)
+		return path:sub(1, 2) == "\\\\" and "\\" or os_separator
+	end
+end)()
+
 local event_loop_exhausted = false
 local uosc_available = false
 local menu_shown = false
@@ -118,6 +179,8 @@ local last_state = nil
 local menu_data = nil
 local search_words = nil
 local search_query = nil
+local dir_menu = false
+local dir_menu_prefixes = nil
 
 local data_protocols = {
     edl = true,
@@ -318,6 +381,7 @@ function close_menu()
     menu_data = nil
     search_words = nil
     search_query = nil
+    dir_menu = false
     menu_shown = false
     osd:update()
     osd.hidden = true
@@ -632,6 +696,21 @@ function show_history(entries, next_page, prev_page, update, return_items)
         return
     end
 
+    local function find_path_prefix(path, path_prefixes)
+        for _, plain in ipairs(path_prefixes.plain) do
+            local start, stop = path:find(plain, 1, true)
+            if start then
+                return start, stop
+            end
+        end
+        for _, pattern in ipairs(path_prefixes.pattern) do
+            local start, stop = path:find(pattern)
+            if start then
+                return start, stop
+            end
+        end
+    end
+
     -- all of these error cases can only happen if the user messes with the history file externally
     local function read_line()
         history:seek("set", state.cursor - max_digits_length)
@@ -693,6 +772,10 @@ function show_history(entries, next_page, prev_page, update, return_items)
             return
         end
 
+        if dir_menu and is_remote then
+            return
+        end
+
         if search_words and not options.use_titles then
             for _, word in ipairs(search_words) do
                 if display_path:lower():find(word, 1, true) == nil then
@@ -706,8 +789,18 @@ function show_history(entries, next_page, prev_page, update, return_items)
         if is_remote then
             state.existing_files[cache_key] = true
             state.known_files[cache_key] = true
-        elseif options.hide_same_dir then
+        elseif options.hide_same_dir or dir_menu then
             dirname, basename = mp.utils.split_path(display_path)
+            if dir_menu then
+                local path_sep = path_separator(dirname)
+                local parent, _ = mp.utils.split_path(dirname:sub(1, -path_sep:len() - 1))
+                local start, stop = find_path_prefix(parent, dir_menu_prefixes)
+                if not start then
+                    return
+                end
+                basename = dirname:match(path_sep .. "(.-)" .. path_sep, stop)
+                dirname = dirname:sub(1, stop + basename:len() + 1)
+            end
             if state.known_dirs[dirname] then
                 return
             end
@@ -736,7 +829,10 @@ function show_history(entries, next_page, prev_page, update, return_items)
             title = ""
         end
 
-        if title == "" then
+
+        if dir_menu then
+            title = basename
+        elseif title == "" then
             if is_remote then
                 title = display_path
             else
@@ -907,11 +1003,11 @@ function memo_close()
 end
 
 function memo_clear()
-    if event_loop_exhausted then return end
     last_state = nil
     search_words = nil
     search_query = nil
     menu_shown = false
+    dir_menu = false
 end
 
 function memo_prev()
@@ -958,7 +1054,7 @@ mp.add_key_binding(nil, "memo-last", function()
     if event_loop_exhausted then return end
 
     local items
-    if last_state and last_state.current_page == 1 and options.hide_duplicates and options.hide_deleted and options.entries >= 2 and not search_words then
+    if last_state and last_state.current_page == 1 and options.hide_duplicates and options.hide_deleted and options.entries >= 2 and not search_words and not dir_menu then
         -- menu is open and we for sure have everything we need
         items = last_state.pages[1]
         last_state = nil
@@ -971,6 +1067,7 @@ mp.add_key_binding(nil, "memo-last", function()
         options.hide_deleted = true
         last_state = nil
         search_words = nil
+        dir_menu = false
         items = show_history(2, false, false, false, true)
         options = options_bak
     end
@@ -1002,6 +1099,19 @@ mp.add_key_binding("h", "memo-history", function()
     if event_loop_exhausted then return end
     last_state = nil
     search_words = nil
+    dir_menu = false
+    show_history(options.entries, false)
+end)
+mp.register_script_message("memo-dirs", function(path_prefixes)
+    if event_loop_exhausted then return end
+    last_state = nil
+    search_words = nil
+    dir_menu = true
+    if path_prefixes then
+        dir_menu_prefixes = parse_path_prefixes(path_prefixes)
+    else
+        dir_menu_prefixes = options.path_prefixes
+    end
     show_history(options.entries, false)
 end)
 

--- a/memo.lua
+++ b/memo.lua
@@ -818,8 +818,19 @@ function show_history(entries, next_page, prev_page, update, return_items)
                 if stat then
                     state.existing_files[cache_key] = true
                 else
-                    state.known_files[cache_key] = true
-                    return
+                    if dir_menu then
+                        local dir = mp.utils.split_path(effective_path)
+                        stat = mp.utils.file_info(dir)
+                        if stat then
+                            full_path = dir
+                        else
+                            state.known_files[cache_key] = true
+                            return
+                        end
+                    else
+                        state.known_files[cache_key] = true
+                        return
+                    end
                 end
             end
         end


### PR DESCRIPTION
~~Here is an initial implementation of the feature from https://github.com/po5/memo/pull/12#issuecomment-1680865209. I was too eager to try that out to wait for a response :smile:~~

Users can define which directories should be listed by specifying how the directory structure of it's parents should look like.

The idea is that e.g. directories inside a directory called "TV Shows" are directories of tv shows.
By defining the prefix "TV Shows" the user can list all recently watched tv shows, providing a convinient for continuing them.

~~I don't really understand why in `memo_clear()` it is necessary to set `tvshow_menu = false` before the `event_loop_exhausted` check, but otherwise it will sometimes open up the menu again after an entry has been selected.~~

Also when opening the menu it flashes a bigger menu before reducing it's size. I assume that's because I don't have enough tv shows in my history to fill up the whole page, but I've never noticed that with the regular history.