### PR TITLE
Prepare for shared-script-properties removal

### DIFF
--- a/memo.lua
+++ b/memo.lua
@@ -411,7 +411,7 @@ function draw_menu(delay)
     local curtain_opacity = 0.7
 
     local alpha = 255 - math.ceil(255 * curtain_opacity)
-    ass.text = string.format("{\\pos(0,0)\\r\\an1\\1c&H000000&\\alpha&H%X&}", alpha)
+    ass.text = string.format("{\\pos(0,0)\\r\\an7\\1c&H000000&\\alpha&H%X&}", alpha)
     ass:draw_start()
     ass:rect_cw(0, 0, width, height)
     ass:draw_stop()

--- a/memo.lua
+++ b/memo.lua
@@ -261,23 +261,37 @@ function update_dimensions()
     draw_menu()
 end
 
-function update_margins()
-    local shared_props = mp.get_property_native("shared-script-properties")
-    local val = shared_props["osc-margins"]
-    if val then
-        -- formatted as "%f,%f,%f,%f" with left, right, top, bottom, each
-        -- value being the border size as ratio of the window size (0.0-1.0)
-        local vals = {}
-        for v in string.gmatch(val, "[^,]+") do
-            vals[#vals + 1] = tonumber(v)
+if mp.utils.shared_script_property_set then
+    function update_margins()
+        local shared_props = mp.get_property_native("shared-script-properties")
+        local val = shared_props["osc-margins"]
+        if val then
+            -- formatted as "%f,%f,%f,%f" with left, right, top, bottom, each
+            -- value being the border size as ratio of the window size (0.0-1.0)
+            local vals = {}
+            for v in string.gmatch(val, "[^,]+") do
+                vals[#vals + 1] = tonumber(v)
+            end
+            margin_top = vals[3] -- top
+            margin_bottom = vals[4] -- bottom
+        else
+            margin_top = 0
+            margin_bottom = 0
         end
-        margin_top = vals[3] -- top
-        margin_bottom = vals[4] -- bottom
-    else
-        margin_top = 0
-        margin_bottom = 0
+        draw_menu()
     end
-    draw_menu()
+else
+    function update_margins()
+        local val = mp.get_property_native('user-data/osc/margins')
+        if val then
+            margin_top = val.t
+            margin_bottom = val.b
+        else
+            margin_top = 0
+            margin_bottom = 0
+        end
+        draw_menu()
+    end
 end
 
 function bind_keys(keys, name, func, opts)
@@ -330,7 +344,8 @@ function open_menu()
     update_dimensions()
     mp.observe_property("osd-dimensions", "native", update_dimensions)
     mp.observe_property("video-out-params", "native", update_dimensions)
-    mp.observe_property("shared-script-properties", "native", update_margins)
+    local margin_prop = mp.utils.shared_script_property_set and "shared-script-properties" or "user-data/osc/margins"
+    mp.observe_property(margin_prop, "native", update_margins)
 
     bind_keys(options.up_binding, "move_up", function()
         last_state.selected_index = math.max(last_state.selected_index - 1, 1)


### PR DESCRIPTION
mpv is about to remove shared-script-properties, so fall back to
user-data in case they aren't available anymore.
https://github.com/mpv-player/mpv/pull/12456

Bonus: During testing I noticed that the curtain for the text menu didn't work, turns out it was drawn in the wrong direction.