### PR TITLE
Open the menu before reading any lines

### DIFF
--- a/memo.lua
+++ b/memo.lua
@@ -805,8 +805,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
                 draw_menu()
             end
         end
-
-        if not return_items and attempts > 0 and attempts % options.entries == 0 and #menu_items ~= item_count then
+        if not return_items and attempts % options.entries == 0 and #menu_items ~= item_count then
             item_count = #menu_items
             local temp_items = {unpack(menu_items)}
             for i = 1, options.entries - item_count do


### PR DESCRIPTION
read_line() can potentially take a long time and not opening the menu before that makes it seem non responsive.