### PR TITLE
Add support for mpv-menu-plugin

### DIFF
--- a/memo.lua
+++ b/memo.lua
@@ -1095,7 +1095,7 @@ function dyn_menu_update()
 
     if #items > 0 then
         for _, item in ipairs(items) do
-            local cmd = string.format("%s '%s' %s", item.value[1], item.value[2], item.value[3])
+            local cmd = string.format("%s \"%s\" %s", item.value[1], item.value[2]:gsub("\\", "\\\\"), item.value[3])
             if item.value[4] then
                 cmd = cmd .. " " .. tostring(item.value[4])
             end

--- a/memo.lua
+++ b/memo.lua
@@ -1100,8 +1100,9 @@ function dyn_menu_update()
                 cmd = cmd .. " " .. tostring(item.value[4])
             end
             submenu[#submenu + 1] = {
-                title = item.title .. "\t" .. item.hint,
+                title = item.title,
                 cmd = cmd,
+                shortcut = item.hint,
             }
         end
         if last_state.cursor > 0 then


### PR DESCRIPTION
Dear po5,
Thanks for your great script, it helps a lot to me. I'm using memo with another mpv c-plugin named [mpv-menu-plugin](https://github.com/tsl0922/mpv-menu-plugin) (Windows only), it is useful too. I think it will be better to intergrate these two mpv plugins, so I modified memo myself.
I'm a mpv begginer, my code must be not so good. 😊

A new line should be added to `input.conf` like this pattern and `mpv-menu-plugin` will automatically update its content:
```
_                  ignore                           #menu: memo-history #@memo
```
Here is a screenshot.
![image](https://github.com/po5/memo/assets/26603498/584361cb-4e8a-41b6-b42d-027ed62d35fb)
