### PR TITLE
Add option to only display titles for web entries

### DIFF
--- a/memo.conf
+++ b/memo.conf
@@ -19,7 +19,9 @@ hide_same_dir=no
 # Date format https://www.lua.org/pil/22.1.html
 timestamp_format=%Y-%m-%d %H:%M:%S
 
-# Display titles instead of filenames when available
+# Display titles instead of filenames when available. 
+# Can be "yes", "no", or "url".
+# "yes" uses titles for all, "no" uses filenames/URLs, "url" uses titles for web URLs only.
 use_titles=yes
 
 # Truncate titles to n characters, 0 to disable

--- a/memo.conf
+++ b/memo.conf
@@ -20,8 +20,8 @@ hide_same_dir=no
 timestamp_format=%Y-%m-%d %H:%M:%S
 
 # Display titles instead of filenames when available. 
-# Can be "yes", "no", or "url".
-# "yes" uses titles for all, "no" uses filenames/URLs, "url" uses titles for web URLs only.
+# Can be "yes", "no", or "web".
+# "yes" uses titles for all, "no" uses filenames/URLs, "web" uses titles for web entries only (eg. youtube videos).
 use_titles=yes
 
 # Truncate titles to n characters, 0 to disable

--- a/memo.lua
+++ b/memo.lua
@@ -187,6 +187,13 @@ local device_protocols = {
     dvdnav = true
 }
 
+local web_protocols = {
+    http = true, 
+    https = true, 
+    ytdl = true, 
+    dvb = true
+}
+
 function utf8_char_bytes(str, i)
     local char_byte = str:byte(i)
     local max_bytes = #str - i + 1
@@ -764,10 +771,7 @@ function path_info(full_path)
         end)
     end
 
-	local valid_protocols = {http = true, https = true, ytdl = true}
-	local is_url = effective_protocol and valid_protocols[effective_protocol]
-
-    return display_path, save_path, effective_path, effective_protocol, is_remote, file_options, is_url
+    return display_path, save_path, effective_path, effective_protocol, is_remote, file_options
 end
 
 function write_history(display)
@@ -941,7 +945,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
         local title_length = title_length_str ~= "" and tonumber(title_length_str) or 0
         local full_path = file_info:sub(title_length + 2)
 
-        local display_path, save_path, effective_path, effective_protocol, is_remote, file_options, is_url = path_info(full_path)
+        local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = path_info(full_path)
         local cache_key = effective_path .. display_path .. (file_options or "")
 
         if options.hide_duplicates and state.known_files[cache_key] then
@@ -952,7 +956,11 @@ function show_history(entries, next_page, prev_page, update, return_items)
             return
         end
 
-        if search_words and not options.use_titles then
+        local is_web = effective_protocol and web_protocols[effective_protocol]
+        --for this specific entry
+        local use_titles_effective = options.use_titles == "yes" or options.use_titles == "web" and is_web
+
+        if search_words and not use_titles_effective then
             for _, word in ipairs(search_words) do
                 if unaccent(display_path):lower():find(word, 1, true) == nil then
                     return
@@ -988,7 +996,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
             end
         end
 
-        if options.hide_deleted and not (search_words and options.use_titles) then
+        if options.hide_deleted and not (search_words and use_titles_effective) then
             if state.known_files[cache_key] and not state.existing_files[cache_key] then
                 return
             end
@@ -1016,7 +1024,8 @@ function show_history(entries, next_page, prev_page, update, return_items)
         end
 
         local title = file_info:sub(1, title_length)
-		if options.use_titles == "no" or (options.use_titles == "url" and not is_url) then
+
+		if not use_titles_effective then
 			title = ""
 		end
 
@@ -1042,7 +1051,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
 
         title = title:gsub("\n", " ")
 
-        if search_words and options.use_titles then
+        if search_words and use_titles_effective then
             for _, word in ipairs(search_words) do
                 if unaccent(title):lower():find(word, 1, true) == nil then
                     return
@@ -1050,7 +1059,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
             end
         end
 
-        if options.hide_deleted and (search_words and options.use_titles) then
+        if options.hide_deleted and (search_words and use_titles_effective) then
             if state.known_files[cache_key] and not state.existing_files[cache_key] then
                 return
             end

--- a/memo.lua
+++ b/memo.lua
@@ -25,7 +25,7 @@ local options = {
     timestamp_format = "%Y-%m-%d %H:%M:%S",
 
     -- Display titles instead of filenames when available
-    use_titles = true,
+    use_titles = "yes",
 
     -- Truncate titles to n characters, 0 to disable
     truncate_titles = 60,
@@ -764,7 +764,10 @@ function path_info(full_path)
         end)
     end
 
-    return display_path, save_path, effective_path, effective_protocol, is_remote, file_options
+	local valid_protocols = {http = true, https = true, ytdl = true}
+	local is_url = effective_protocol and valid_protocols[effective_protocol]
+
+    return display_path, save_path, effective_path, effective_protocol, is_remote, file_options, is_url
 end
 
 function write_history(display)
@@ -938,7 +941,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
         local title_length = title_length_str ~= "" and tonumber(title_length_str) or 0
         local full_path = file_info:sub(title_length + 2)
 
-        local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = path_info(full_path)
+        local display_path, save_path, effective_path, effective_protocol, is_remote, file_options, is_url = path_info(full_path)
         local cache_key = effective_path .. display_path .. (file_options or "")
 
         if options.hide_duplicates and state.known_files[cache_key] then
@@ -1013,9 +1016,9 @@ function show_history(entries, next_page, prev_page, update, return_items)
         end
 
         local title = file_info:sub(1, title_length)
-        if not options.use_titles then
-            title = ""
-        end
+		if options.use_titles == "no" or (options.use_titles == "url" and not is_url) then
+			title = ""
+		end
 
         if dir_menu then
             title = basename


### PR DESCRIPTION
I added a new `url` option for the `use_titles` option in the config. 

When `use_titles=url` is set, the script will only display titles for web entries (e.g., YouTube or Vimeo URLs) and fall back to filenames for everything else. It leverages the fact that the config options are set as strings, so this shouldn't break existing configs. I also changed the default config file to make the options for this more clear.

Decided to add this because I use `no` so I can see the specific filenames of items, but when I do that, Youtube URLs offer absolutely no info.

I saw what was said in #12, so I made sure that this change is based on the script's already existing logic for determining the protocol. So far, I only have it set to detect ytdl, http, and https as URLs. More protocols can easily be added to the list if necessary. And if you think the use of the term "URL" is too liberal (since that could refer to FTP too) I can always change the variable and setting names to "web" or something instead.

One other change I could make is to update every other call of `path_info()` to include the `is_url` variable. That would make it clearer what the outputs of the function are for future maintainers.