### PR TITLE
Add option to collapse archived files

### DIFF
--- a/memo.conf
+++ b/memo.conf
@@ -25,7 +25,7 @@ use_titles=yes
 # For files within an archive, only show the most recent entry per archive
 # This also opens the archive itself, not the file within the archive, when opened from memo's menu
 # In other words, memo won't track files within archives, but the archive itself instead
-collapse_archive_entries=yes
+collapse_archive_entries=no
 
 # Truncate titles to n characters, 0 to disable
 truncate_titles=60

--- a/memo.conf
+++ b/memo.conf
@@ -16,16 +16,19 @@ hide_deleted=yes
 # Display only the latest file from each directory
 hide_same_dir=no
 
+# Display only the latest file from each archive
+# Does not track nested archives - displays the latest file from only the outermost archive
+hide_same_archive=no
+
+# Display the filename of the archive instead of the inner file being opened
+# Applies to archived files when hide_same_archive is enabled
+display_archive_name=no
+
 # Date format https://www.lua.org/pil/22.1.html
 timestamp_format=%Y-%m-%d %H:%M:%S
 
 # Display titles instead of filenames when available
 use_titles=yes
-
-# For files within an archive, only show the most recent entry per archive
-# This also opens the archive itself, not the file within the archive, when opened from memo's menu
-# In other words, memo won't track files within archives, but the archive itself instead
-collapse_archive_entries=no
 
 # Truncate titles to n characters, 0 to disable
 truncate_titles=60

--- a/memo.conf
+++ b/memo.conf
@@ -20,8 +20,8 @@ hide_same_dir=no
 # Does not track nested archives - displays the latest file from only the outermost archive
 hide_same_archive=no
 
-# Display the filename of the archive instead of the inner file being opened
-# Applies to archived files when hide_same_archive is enabled
+# Display the filename of the outermost archive instead of title or inner filename
+# Applies to archived files only when hide_same_archive is also enabled
 display_archive_name=no
 
 # Date format https://www.lua.org/pil/22.1.html

--- a/memo.conf
+++ b/memo.conf
@@ -22,6 +22,11 @@ timestamp_format=%Y-%m-%d %H:%M:%S
 # Display titles instead of filenames when available
 use_titles=yes
 
+# For files within an archive, only show the most recent entry per archive
+# This also opens the archive itself, not the file within the archive, when opened from memo's menu
+# In other words, memo won't track files within archives, but the archive itself instead
+collapse_archive_entries=yes
+
 # Truncate titles to n characters, 0 to disable
 truncate_titles=60
 

--- a/memo.lua
+++ b/memo.lua
@@ -844,6 +844,7 @@ function show_history(entries, next_page, prev_page, update, return_items)
     local menu_items = {}
     local state = (prev_page or next_page) and last_state or {
         known_dirs = {},
+        known_archives = {},
         known_files = {},
         existing_files = {},
         cursor = history:seek("end"),
@@ -947,8 +948,8 @@ function show_history(entries, next_page, prev_page, update, return_items)
         local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = path_info(full_path)
         local cache_key = effective_path .. display_path .. (file_options or "")
 
-        if options.hide_same_archive and effective_protocol == "archive" then
-            cache_key = effective_path .. (file_options or "")
+        if options.hide_same_archive and options.display_archive_name and effective_protocol == "archive" then
+            display_path = effective_path
         end
 
         if options.hide_duplicates and state.known_files[cache_key] then
@@ -972,26 +973,35 @@ function show_history(entries, next_page, prev_page, update, return_items)
         if is_remote then
             state.existing_files[cache_key] = true
             state.known_files[cache_key] = true
-        elseif options.hide_same_dir or dir_menu then
-            dirname, basename = mp.utils.split_path(display_path)
-            if dir_menu then
-                if dirname == "." then return end
-                local unix_dirname = dirname:gsub("\\", "/")
-                local parent, _ = mp.utils.split_path(unix_dirname:sub(1, -2))
-                local start, stop = find_path_prefix(parent, dir_menu_prefixes)
-                if not start then
+        else
+            if options.hide_same_archive and effective_protocol == "archive" then
+                local archive_key = effective_path .. (file_options or "")
+                if state.known_archives[archive_key] then
                     return
                 end
-                basename = unix_dirname:match("/(.-)/", stop)
-                if basename == nil then return end
-                start, stop = dirname:find(basename, stop, true)
-                dirname = dirname:sub(1, stop + 1)
+                state.known_archives[archive_key] = true
             end
-            if state.known_dirs[dirname] then
-                return
-            end
-            if dirname ~= "." then
-                state.known_dirs[dirname] = true
+            if options.hide_same_dir or dir_menu then
+                dirname, basename = mp.utils.split_path(display_path)
+                if dir_menu then
+                    if dirname == "." then return end
+                    local unix_dirname = dirname:gsub("\\", "/")
+                    local parent, _ = mp.utils.split_path(unix_dirname:sub(1, -2))
+                    local start, stop = find_path_prefix(parent, dir_menu_prefixes)
+                    if not start then
+                        return
+                    end
+                    basename = unix_dirname:match("/(.-)/", stop)
+                    if basename == nil then return end
+                    start, stop = dirname:find(basename, stop, true)
+                    dirname = dirname:sub(1, stop + 1)
+                end
+                if state.known_dirs[dirname] then
+                    return
+                end
+                if dirname ~= "." then
+                    state.known_dirs[dirname] = true
+                end
             end
         end
 
@@ -1023,15 +1033,8 @@ function show_history(entries, next_page, prev_page, update, return_items)
         end
 
         local title = file_info:sub(1, title_length)
-        if not options.use_titles then
+        if not options.use_titles or options.display_archive_name then
             title = ""
-        end
-
-        -- if collapsing archive entries, display the archive's filename
-        if options.hide_same_archive and options.display_archive_name and effective_protocol == "archive" then
-            local _, archive_basename = mp.utils.split_path(effective_path)
-            archive_basename = archive_basename and archive_basename ~= "" and archive_basename or title
-            title = archive_basename
         end
 
         if dir_menu then

--- a/memo.lua
+++ b/memo.lua
@@ -58,7 +58,7 @@ local options = {
 
     -- Only show the most-recent entry per archive
     -- and open the archive itself (no inner-file) when selected.
-    collapse_archive_entries = true
+    collapse_archive_entries = false
 }
 
 function parse_path_prefixes(path_prefixes)

--- a/memo.lua
+++ b/memo.lua
@@ -54,7 +54,11 @@ local options = {
     --   Opening the file "/data/TV Shows/Comedy/Curb Your Enthusiasm/S4/E06.mkv" will
     --   lead to "Curb Your Enthusiasm" to be shown in the directory menu. Opening
     --   of that entry will then open that file again.
-    path_prefixes = "pattern:.*"
+    path_prefixes = "pattern:.*",
+
+    -- Only show the most-recent entry per archive
+    -- and open the archive itself (no inner-file) when selected.
+    collapse_archive_entries = true
 }
 
 function parse_path_prefixes(path_prefixes)
@@ -939,6 +943,31 @@ function show_history(entries, next_page, prev_page, update, return_items)
         local full_path = file_info:sub(title_length + 2)
 
         local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = path_info(full_path)
+
+        -- detect archive base file from the raw history full_path string
+        local archive_base = nil
+        if full_path and full_path:find("^archive://") then
+            archive_base = full_path:match("^archive://(.+)")
+            if archive_base then
+                archive_base = archive_base:gsub("%%7C", "|")
+                archive_base = archive_base:match("^(.-)|") or archive_base
+            end
+        end
+
+        -- if collapse_archive_entries is enabled and this entry is from an archive:
+        -- 1. existence checks apply to the archive file (not inner file)
+        -- 2. duplicates are collapsed per-archive (not per-inner-file)
+        if options.collapse_archive_entries and archive_base then
+            local ok_normalized = pcall(function()
+                effective_path = normalize(archive_base)
+            end)
+            if not ok_normalized then
+                effective_path = archive_base
+            end
+            save_path = effective_path
+            display_path = archive_base
+        end
+        
         local cache_key = effective_path .. display_path .. (file_options or "")
 
         if options.hide_duplicates and state.known_files[cache_key] then
@@ -1099,6 +1128,13 @@ function show_history(entries, next_page, prev_page, update, return_items)
         state.known_files[cache_key] = true
 
         local command = {"loadfile", full_path, "replace"}
+
+        -- if collapse_archive_entries is enabled, open the archive file itself (no inner path / no archive://)
+        if options.collapse_archive_entries and archive_base then
+            local archive_to_open = archive_base
+            local ok_norm = pcall(function() archive_to_open = normalize(archive_to_open) end)
+            command = {"loadfile", archive_to_open, "replace"}
+        end
 
         if file_options then
             command[2] = display_path

--- a/memo.lua
+++ b/memo.lua
@@ -21,6 +21,12 @@ local options = {
     -- Display only the latest file from each directory
     hide_same_dir = false,
 
+    -- Display only the latest file from each archive
+    hide_same_archive = false,
+
+    -- If hide_same_archive enabled, display archive filename instead of inner file filename
+    display_archive_name = false,
+
     -- Date format https://www.lua.org/pil/22.1.html
     timestamp_format = "%Y-%m-%d %H:%M:%S",
 
@@ -54,11 +60,7 @@ local options = {
     --   Opening the file "/data/TV Shows/Comedy/Curb Your Enthusiasm/S4/E06.mkv" will
     --   lead to "Curb Your Enthusiasm" to be shown in the directory menu. Opening
     --   of that entry will then open that file again.
-    path_prefixes = "pattern:.*",
-
-    -- Only show the most-recent entry per archive
-    -- and open the archive itself (no inner-file) when selected.
-    collapse_archive_entries = false
+    path_prefixes = "pattern:.*"
 }
 
 function parse_path_prefixes(path_prefixes)
@@ -756,7 +758,7 @@ function path_info(full_path)
     -- don't resolve magnet-style paths
     local protocol_start, protocol_end, protocol = full_path:find("^(%a[%w.+-]-):%?")
     if protocol_end then
-        return full_path, full_path, protocol, true, nil
+        return full_path, full_path, full_path, protocol, true, nil
     end
 
     local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = resolve(nil, nil, full_path, nil, false)
@@ -943,32 +945,11 @@ function show_history(entries, next_page, prev_page, update, return_items)
         local full_path = file_info:sub(title_length + 2)
 
         local display_path, save_path, effective_path, effective_protocol, is_remote, file_options = path_info(full_path)
-
-        -- detect archive base file from the raw history full_path string
-        local archive_base = nil
-        if full_path and full_path:find("^archive://") then
-            archive_base = full_path:match("^archive://(.+)")
-            if archive_base then
-                archive_base = archive_base:gsub("%%7C", "|")
-                archive_base = archive_base:match("^(.-)|") or archive_base
-            end
-        end
-
-        -- if collapse_archive_entries is enabled and this entry is from an archive:
-        -- 1. existence checks apply to the archive file (not inner file)
-        -- 2. duplicates are collapsed per-archive (not per-inner-file)
-        if options.collapse_archive_entries and archive_base then
-            local ok_normalized = pcall(function()
-                effective_path = normalize(archive_base)
-            end)
-            if not ok_normalized then
-                effective_path = archive_base
-            end
-            save_path = effective_path
-            display_path = archive_base
-        end
-        
         local cache_key = effective_path .. display_path .. (file_options or "")
+
+        if options.hide_same_archive and effective_protocol == "archive" then
+            cache_key = effective_path .. (file_options or "")
+        end
 
         if options.hide_duplicates and state.known_files[cache_key] then
             return
@@ -1046,9 +1027,9 @@ function show_history(entries, next_page, prev_page, update, return_items)
             title = ""
         end
 
-        -- if collapsing archive entries, prefer the archive's filename as the title
-        if options.collapse_archive_entries and archive_base then
-            local _, archive_basename = mp.utils.split_path(archive_base)
+        -- if collapsing archive entries, display the archive's filename
+        if options.hide_same_archive and options.display_archive_name and effective_protocol == "archive" then
+            local _, archive_basename = mp.utils.split_path(effective_path)
             archive_basename = archive_basename and archive_basename ~= "" and archive_basename or title
             title = archive_basename
         end
@@ -1135,13 +1116,6 @@ function show_history(entries, next_page, prev_page, update, return_items)
         state.known_files[cache_key] = true
 
         local command = {"loadfile", full_path, "replace"}
-
-        -- if collapse_archive_entries is enabled, open the archive file itself (no inner path / no archive://)
-        if options.collapse_archive_entries and archive_base then
-            local archive_to_open = archive_base
-            local ok_norm = pcall(function() archive_to_open = normalize(archive_to_open) end)
-            command = {"loadfile", archive_to_open, "replace"}
-        end
 
         if file_options then
             command[2] = display_path

--- a/memo.lua
+++ b/memo.lua
@@ -1046,6 +1046,13 @@ function show_history(entries, next_page, prev_page, update, return_items)
             title = ""
         end
 
+        -- if collapsing archive entries, prefer the archive's filename as the title
+        if options.collapse_archive_entries and archive_base then
+            local _, archive_basename = mp.utils.split_path(archive_base)
+            archive_basename = archive_basename and archive_basename ~= "" and archive_basename or title
+            title = archive_basename
+        end
+
         if dir_menu then
             title = basename
         elseif title == "" then

--- a/memo.lua
+++ b/memo.lua
@@ -1054,6 +1054,9 @@ function show_history(entries, next_page, prev_page, update, return_items)
                 if not dirname then
                     dirname, basename = mp.utils.split_path(effective_display_path)
                 end
+                if effective_protocol == "archive" and not options.display_archive_name then
+                    basename = effective_display_path
+                end
                 title = basename ~= "" and basename or display_path
                 if file_options then
                     title = display_path .. " " .. title

--- a/memo.lua
+++ b/memo.lua
@@ -1033,7 +1033,11 @@ function show_history(entries, next_page, prev_page, update, return_items)
         end
 
         local title = file_info:sub(1, title_length)
-        if not options.use_titles or options.display_archive_name then
+        if not options.use_titles then
+            title = ""
+        end
+
+        if options.hide_same_archive and options.display_archive_name and effective_protocol == "archive" then
             title = ""
         end
 


### PR DESCRIPTION
The main purpose of this feature is to make memo compatible with the mpv manga reader script.

In its current state, memo will add an entry to the history log for every single page in a manga file, and when you try to open one from memo's menu, it will open only that page instead of the entire manga file.

When enabled, memo will only show the most recent entry for any archive. If you open one of these entries from memo's history menu, it will tell mpv to load the path to the archive, not the path to any specific file within the archive. This also allows mpv to auto-resume the manga file from where the reader left off.

This feature only changes the show_history code, so every page is still added to the history log.